### PR TITLE
Corrige horário nos ofícios em documentos gerais 

### DIFF
--- a/resources/views/agendamentos/files/partials/form.blade.php
+++ b/resources/views/agendamentos/files/partials/form.blade.php
@@ -12,7 +12,7 @@
         <div class="col-sm">
             <label for="arquivo-do-trabalho" class="required"><b>Arquivo da Defesa</b></label>
             <input type="file" class="form-control-file" id="arquivo-do-trabalho" name="file">
-            <span class="badge badge-warning"><b>Atenção:</b> Os arquivos a serem enviados devem ter no máximo 12mb.</span><br>
+            <span class="badge badge-warning"><b>Atenção:</b> Os arquivos a serem enviados devem ter no máximo 120mb.</span><br>
         </div>
         <div class="col-auto">
             <button type="submit" style="margin-top:2.98em" class="btn btn-success float-right">Enviar</button> 

--- a/resources/views/pdfs/documentos_gerais/titulares.blade.php
+++ b/resources/views/pdfs/documentos_gerais/titulares.blade.php
@@ -74,7 +74,8 @@
                 {!! $configs->importante_oficio !!}
             </div>
             <div> 
-                <i>Data e hora da defesa:  </i> <b> {{$agendamento->data}} {{$agendamento->hora}} </b> <br> 
+                @php(\App\Models\Agendamento::formatDataHorario($agendamento))
+                <i>Data e hora da defesa:  </i> <b> {{$agendamento->data}}, às {{$agendamento->horario}} </b> <br> 
                 <i>Local:</i> <b> {{$agendamento->sala}} </b> - Administração da FFLCH 
             </div>  
             <i>Composição da banca examinadora:</i> 


### PR DESCRIPTION
A data e horário da defesa agendada só era exibida nos ofícios titulares em documentos_bancas.
Foi corrigida para ser mostrada em documentos_gerais.

Também corrige limite de upload de arquivo exibido no agendamento.
Antes exibia apenas 12mb, foi corrigido para 120mb.

Fix #120