### PR TITLE
Correção de erro ao deletar defesa com arquivo(s) anexado(s)

### DIFF
--- a/app/Http/Controllers/AgendamentoController.php
+++ b/app/Http/Controllers/AgendamentoController.php
@@ -126,7 +126,6 @@ class AgendamentoController extends Controller
             Storage::delete($file->path);
             $file->delete();
         }
-        $agendamento->files()->delete();
         $agendamento->delete();
         return redirect('/agendamentos');
     }

--- a/app/Http/Controllers/AgendamentoController.php
+++ b/app/Http/Controllers/AgendamentoController.php
@@ -16,6 +16,7 @@ use App\Mail\ReciboExternoMail;
 use App\Mail\ProLaboreMail;
 use App\Mail\PassagemMail;
 use App\Mail\DadosProfExternoMail;
+use Storage;
 
 class AgendamentoController extends Controller
 {
@@ -121,6 +122,10 @@ class AgendamentoController extends Controller
     {
         $this->authorize('admin');
         $agendamento->bancas()->delete();
+        foreach($agendamento->files as $file){
+            Storage::delete($file->path);
+            $file->delete();
+        }
         $agendamento->files()->delete();
         $agendamento->delete();
         return redirect('/agendamentos');

--- a/app/Http/Controllers/AgendamentoController.php
+++ b/app/Http/Controllers/AgendamentoController.php
@@ -121,6 +121,7 @@ class AgendamentoController extends Controller
     {
         $this->authorize('admin');
         $agendamento->bancas()->delete();
+        $agendamento->files()->delete();
         $agendamento->delete();
         return redirect('/agendamentos');
     }

--- a/resources/views/pdfs/documentos_bancas/declaracao.blade.php
+++ b/resources/views/pdfs/documentos_bancas/declaracao.blade.php
@@ -79,7 +79,8 @@
         @endforeach
     </table>
 	<div style="margin-top:2cm;" align="center"> 
-        Atenciosamente,<br>  
+        Atenciosamente,<br><br><br><br><br>
+        _____________________________________________________________ <br>
         <b>
             {{Auth::user()->name}} @if($pessoa::cracha(Auth::user()->codpes)) - Defesas de Mestrado e Doutorado da {{$pessoa::cracha(Auth::user()->codpes)['nomorg']}}/USP @endif 
         </b>

--- a/resources/views/pdfs/documentos_gerais/declaracoes.blade.php
+++ b/resources/views/pdfs/documentos_gerais/declaracoes.blade.php
@@ -80,7 +80,8 @@
             @endforeach
         </table>
         <div style="margin-top:2cm;" align="center"> 
-            Atenciosamente,<br>  
+            Atenciosamente,<br><br><br><br><br>
+            _____________________________________________________________ <br>  
             <b>
                 {{Auth::user()->name}} @if($pessoa::cracha(Auth::user()->codpes)) - Defesas de Mestrado e Doutorado da {{$pessoa::cracha(Auth::user()->codpes)['nomorg']}}/USP @endif 
             </b>


### PR DESCRIPTION
Foi inserido a exclusão de arquivos em cascata no método destroy.
Assim como, foi adicionado maior espaçamento para assinatura nos arquivos de declaração.

Fix #122