### PR TITLE
Docente externo recebe e-mail para criação de sala virtual e arrumando a permissão do Gate Biblioteca

### DIFF
--- a/app/Console/Commands/EmailSalavirtual.php
+++ b/app/Console/Commands/EmailSalavirtual.php
@@ -43,7 +43,7 @@ class EmailSalavirtual extends Command
             ->get();
 
         foreach($agendamentos as $agendamento){
-            $email = Pessoa::retornarEmailUsp($agendamento->orientador);
+            $email = Pessoa::email($agendamento->orientador);
             if($email) {
                 Mail::to($email)->queue(new MailSalaVirtual($agendamento));
                 $agendamento->enviar_email = TRUE; //mostra que o e-mail já foi enviado

--- a/app/Http/Controllers/AgendamentoController.php
+++ b/app/Http/Controllers/AgendamentoController.php
@@ -97,7 +97,7 @@ class AgendamentoController extends Controller
 
     public function show(Agendamento $agendamento)
     {
-        $this->authorize('admin');
+        $this->authorize('biblioteca');
         $agendamento->nome_area = ReplicadoUtils::nomeAreaPrograma($agendamento->area_programa);
         $dadosJanus = ReplicadoUtils::retornarDadosJanus($agendamento->codpes);
         return view('agendamentos.show', compact(['agendamento','dadosJanus']));


### PR DESCRIPTION
- Caso o orientador seja um docente externo que não possui e-mail usp, o sistema enviará para o e-mail que está cadastrado no sistema;
- Arrumado o erro de usuários com permissão de Biblioteca (env) não conseguirem acessar a páginas para publicarem o link da defesa;