### PR TITLE
Alteração na página de Comunicação e pegando dados dos docentes/orientadores pelo replicado

### DIFF
--- a/app/Http/Controllers/CommunicationController.php
+++ b/app/Http/Controllers/CommunicationController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Http\Request;
 use App\Http\Requests\CommunicationRequest;
+use App\Utils\ReplicadoUtils;
 use App\Models\Agendamento;
 use App\Models\Communication;
 use Illuminate\Support\Facades\Auth;
@@ -14,29 +15,19 @@ class CommunicationController extends Controller
 {
     public function index(){
         Gate::authorize('comunicacao');
-        //$comunicacao = Agendamento::where('status',1)->get();
-
-        $agendamentos = Communication::rightJoin('agendamentos','agendamentos.id','communications.agendamento_id')
-        ->where('agendamentos.status',1)
+        $agendamentos = Agendamento::where('status',1)
         ->orderBy('data_horario','desc')
-        ->get();
-
-        return view('comunicacao.index', ['agendamentos' => $agendamentos]);
+        ->paginate(15);
+        
+        foreach($agendamentos as  $agendamento){
+            $dadosJanus = ReplicadoUtils::retornarDadosJanus($agendamento->codpes);
+        }
+        return view('comunicacao.index', ['agendamentos' => $agendamentos, 'dadosJanus' => $dadosJanus]);
     }
 
     public function show(Agendamento $comunicacao){
         Gate::authorize('comunicacao');
-        return view('comunicacao.show', ['comunicacao' => $comunicacao]);
+        $dadosJanus = ReplicadoUtils::retornarDadosJanus($agendamento->codpes);
+        return view('comunicacao.show', ['comunicacao' => $comunicacao, 'dadosJanus' => $dadosJanus]);
     }
-    public function store(Request $request, Agendamento $agendamento){
-        Gate::authorize('comunicacao');
-        $comunicacao = new Communication;
-        $comunicacao->nome = Auth::user()->name;
-        $comunicacao->codpes = Auth::user()->codpes;
-        $comunicacao->agendamento_id = $request->agendamento_id;
-        $comunicacao->save();
-        request()->session()->flash('alert-success','Defesa divulgada');
-        return redirect('/comunicacao');
-    }
-
 }

--- a/app/Models/Agendamento.php
+++ b/app/Models/Agendamento.php
@@ -8,10 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 use Carbon\Carbon;
 use Uspdev\Replicado\Posgraduacao;
 use App\Utils\ReplicadoUtils;
+use App\Models\User;
 use App\Models\Banca;
 use App\Models\Docente;
-use App\Models\User;
 use App\Models\Communication;
+use Uspdev\Replicado\Pessoa;
 
 class Agendamento extends Model
 {
@@ -98,15 +99,19 @@ class Agendamento extends Model
     }
 
     public static function dadosProfessor($codpes){
-        $dados = Docente::where('n_usp', '=', $codpes)->first();
-        if($dados != null){
-            return $dados;
-        }
-        return new Docente;
+        return Pessoa::listarVinculosAtivos($codpes)[0];
+    }
+
+    public static function retornarDadosProfessor($codpes){
+        return Pessoa::dump($codpes); //usado para retornar o CPF
     }
 
     public function nomeUsuario($id){
         return User::where('id',$id)->first();
+    }
+
+    public static function endereco($codpes){
+        return Pessoa::obterEndereco($codpes); //método já retorna o endereço completo
     }
 
     //Função para devolver valores de select status

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -39,7 +39,7 @@ class Config extends Model
             $docenteNome = 'Professor não cadastrado';
         }
         else{
-            $docenteNome = Agendamento::dadosProfessor($professor->codpes)->nome;
+            $docenteNome = Agendamento::dadosProfessor($professor->codpes)['nompes'];
         }
         $configs['declaracao'] = str_replace(
             ["%docente_nome","%nivel","%candidato_nome", "%titulo"],
@@ -56,7 +56,7 @@ class Config extends Model
                     $docenteNome = 'Professor não cadastrado';
                 }
                 else{
-                    $docenteNome = Agendamento::dadosProfessor($presidente->codpes)->nome;
+                    $docenteNome = Agendamento::dadosProfessor($presidente->codpes)['nompes'];
                 }
                 $configs['declaracao'] = str_replace("%orientador", $docenteNome, $configs['declaracao']);
             }
@@ -73,7 +73,7 @@ class Config extends Model
             $docenteNome = 'Professor não cadastrado';
         }
         else{
-            $docenteNome = Agendamento::dadosProfessor($professor->codpes)->nome;
+            $docenteNome = Agendamento::dadosProfessor($professor->codpes)['nompes'];
         }
 
         if($agendamento['nivel'] == 'Mestrado'){
@@ -96,7 +96,7 @@ class Config extends Model
                     $docenteNome = 'Professor não cadastrado';
                 }
                 else{
-                    $docenteNome = Agendamento::dadosProfessor($presidente->codpes)->nome;
+                    $docenteNome = Agendamento::dadosProfessor($presidente->codpes)['nompes'];
                 }
                 $configs['statement'] = str_replace("%orientador", $docenteNome, $configs['statement']);
             }
@@ -114,7 +114,7 @@ class Config extends Model
             $docenteNome = 'Professor não cadastrado';
         }
         else{
-            $docenteNome = Agendamento::dadosProfessor($professor->codpes)->nome;
+            $docenteNome = Agendamento::dadosProfessor($professor->codpes)['nompes'];
         }
         $configs['mail_docente'] = str_replace(
             ["%docente_nome","%candidato_nome", "%data_defesa", "%local_defesa", "%agendamento", "%docente", "%token"],
@@ -187,7 +187,7 @@ class Config extends Model
     public static function configMailSalaVirtual(Agendamento $agendamento){
         $configs = Config::orderbyDesc('created_at')->first();
 
-        $docenteNome = Agendamento::dadosProfessor($agendamento->orientador)->nome;
+        $docenteNome = Agendamento::dadosProfessor($agendamento->orientador)['nompes'];
 
         $configs['mail_sala_virtual'] = str_replace(
             ["%docente", "%nusp", "%candidato", "%codpes", "%titulo", "%tipo"],

--- a/database/migrations/2025_01_14_151612_drop_communications_table.php
+++ b/database/migrations/2025_01_14_151612_drop_communications_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('communications', function (Blueprint $table){
+            $table->dropIfExists('communications');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('communications', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/agendamentos/form.blade.php
+++ b/resources/views/agendamentos/form.blade.php
@@ -64,12 +64,12 @@
                 {{-- 1. Situação em que não houve tentativa de submissão e é uma edição --}}
                 @if (old('area_programa') == '' and isset($agendamento->area_programa))
                 <option value="{{ $option['codare'] }}" {{ ( $agendamento->area_programa == $option['codare']) ? 'selected' : ''}}>
-                    {{$option['nomare']}}
+                    {{$option['codare']}} - {{$option['nomare']}}
                 </option>
                 {{-- 2. Situação em que houve tentativa de submissão, o valor de old prevalece --}}
                 @else
                 <option value="{{$option['codare']}}" {{ ( old('area_programa') == $option['codare']) ? 'selected' : ''}}>
-                    {{$option['nomare']}}
+                    {{$option['codare']}} - {{$option['nomare']}}
                 </option>
                 @endif
             @endforeach
@@ -133,11 +133,19 @@
 <div class="row form-group">
     <div class="col-sm">
         <label for="data" class="required">Data</label>
+        @if(!$agendamento->data_horario)
+        <input type="text" name="data" class="form-control datepicker data" autocomplete="off">
+        @else
         <input type="text" name="data" class="form-control datepicker data" autocomplete="off" value="{{ old('data_horario', date('d/m/Y',strtotime($agendamento->data_horario))) }}">
+        @endif
     </div>
     <div class="col-sm">
         <label for="horario" class="required">Horário</label>
+        @if(!$agendamento->data_horario)
+        <input type="text" name="horario" class="form-control horario">
+        @else
         <input type="text" name="horario" class="form-control horario" value="{{ old('data_horario', date('H:i', strtotime($agendamento->data_horario))) }}">
+        @endif
     </div>
 </div>
 <div class="row form-group">
@@ -176,6 +184,6 @@
 
 <div class="row form-group">
     <div class="col-sm">
-        <button type="submit" class="btn btn-success float-right">Enviar</button>
+        <button dusk="enviar_agendamento" type="submit" class="btn btn-success float-right">Enviar</button>
     </div>
 </div>

--- a/resources/views/agendamentos/partials/banca.blade.php
+++ b/resources/views/agendamentos/partials/banca.blade.php
@@ -27,7 +27,7 @@
                 @foreach ($agendamento->bancas as $banca)
                     <tr>
                         @can('logado')<td>{{ $banca->codpes }}</td>@endcan
-                        <td>{{ $agendamento->dadosProfessor($banca->codpes)->nome  ?? 'Professor não cadastrado'}}</td>
+                        <td>{{ $agendamento->dadosProfessor($banca->codpes)['nompes'] }}</td>
                         <td>{{ $banca->presidente }}</td>
                         <td>{{ $banca->tipo }}</td>
                         @can('admin')

--- a/resources/views/agendamentos/partials/defesa.blade.php
+++ b/resources/views/agendamentos/partials/defesa.blade.php
@@ -10,7 +10,7 @@
             <b>Nível:</b> {{$agendamento->nivel}}</br>
             <b>Programa:</b> {{$agendamento->nome_area}}</br>
             @can('logado')<b>Orientador Votante:</b> {{$agendamento->orientador_votante}}</br>@endcan
-            <b>Orientador:</b> {{$agendamento->nome_orientador ?? $agendamento->dadosProfessor($agendamento->orientador)->nome}} @if($agendamento->co_orientador) e {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)->nome}} @endif</br>
+            <b>Orientador:</b> {{$agendamento->dadosProfessor($agendamento->orientador)['nompes'] }} @if($agendamento->co_orientador) e {{$agendamento->dadosProfessor($agendamento->co_orientador)['nompes'] }} @endif</br>
             <b>Data:</b> {{ date('d/m/Y', strtotime($agendamento->data_horario))}} às {{date('H:i', strtotime($agendamento->data_horario))}}</br>
             <b>Local:</b> {{$agendamento->sala}}</br>
             @if($agendamento->tipo == 'Virtual' || $agendamento->tipo == 'Hibrido')

--- a/resources/views/agendamentos/partials/recibos.blade.php
+++ b/resources/views/agendamentos/partials/recibos.blade.php
@@ -17,7 +17,7 @@
                 <tr>
                     <form action="/agendamentos/{{$agendamento->id}}/bancas/{{$banca->id}}/recibos/exibir_recibo_externo" class="form-group" method="POST">
                         @csrf
-                        <td>{{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}}</td>
+                        <td>{{$agendamento->dadosProfessor($banca->codpes)['nompes']}}</td>
                         <td> <input type="text" class="datepicker form-control" size="7" autocomplete="off" name="ida"> </td>
                         <td> <input type="text" class="datepicker form-control" size="7" autocomplete="off" name="volta"> </td>
                         <td> <input type="text" class="form-control" size="7" name="origem"> </td>
@@ -54,7 +54,7 @@
                     <tr>
                         <form class="form-group" action="/agendamentos/{{$agendamento->id}}/bancas/{{$banca->id}}/proex" method="POST">
                             @csrf
-                            <td> {{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}} </td>
+                            <td> {{$agendamento->dadosProfessor($banca->codpes)['nompes']}} </td>
                             <td><input type="text" class="form-control" size="4" name="importancia"></td>
                             <td><input type="text" class="form-control" size="4" name="periodo"></td>
                             <td><input type="text" class="form-control" size="4" name="valor"></td>
@@ -90,7 +90,7 @@
                     <tr>
                         <form action="/agendamentos/{{$agendamento->id}}/bancas/{{$banca->id}}/proap" class="form-group" method="POST">
                             @csrf
-                            <td>{{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}}</td>
+                            <td>{{$agendamento->dadosProfessor($banca->codpes)['nompes']}}</td>
                             <td><input type="text" class="form-control" size="1" name="ano"></td>
                             <td><input type="text" class="form-control" size="1" name="diaria_proap"></td>
                             <td><input type="text" class="form-control" size="6" name="origem"></td>
@@ -124,7 +124,7 @@
                     <tr>
                         <form action="/agendamentos/{{$agendamento->id}}/bancas/{{$banca->id}}/passagem" class="form-group" method="POST">
                             @csrf
-                            <td>{{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}}</td>
+                            <td>{{$agendamento->dadosProfessor($banca->codpes)['nompes']}}</td>
                             <td><input  type="text" class="form-control" size="6" name="ida"></td>
                             <td><input type="text" class="form-control" size="6" name="volta"></td>
                             <td><input  type="text" class="form-control" size="6" name="trajeto"></td>
@@ -155,7 +155,7 @@
                     <tr>
                         <form action="/agendamentos/{{$agendamento->id}}/bancas/{{$banca->id}}/auxilio_passagem" class="form-group" method="POST">
                             @csrf
-                            <td>{{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}}</td>
+                            <td>{{$agendamento->dadosProfessor($banca->codpes)['nompes']}}</td>
                             <td><input  type="text" size="6" class="form-control datepicker" name="partida"></td>
                             <td><input  type="text" size="6" class="form-control datepicker" name="retorno"></td>
                             <td><input  type="text" size="6" class="form-control" name="itinerario"></td>
@@ -182,7 +182,7 @@
                 <tr>
                     <form action="/agendamentos/{{$agendamento->id}}/bancas/{{$banca->id}}/recibos/exibir_email_docente" class="form-group" method="POST">
                         @csrf 
-                        <td>{{ $agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}}</td>
+                        <td>{{ $agendamento->dadosProfessor($banca->codpes)['nompes']}}</td>
                         <td><button type="submit" size="4" class="btn btn-primary" @if($agendamento->dadosProfessor($banca->codpes) == null) disabled @endif><b>Visualizar E-mail</b></button></td>
                     </form> 
                 </tr>

--- a/resources/views/anteriores.blade.php
+++ b/resources/views/anteriores.blade.php
@@ -87,7 +87,7 @@
                     <td>{{ $agendamento->sala }}</td>
                     <td> 
                         @foreach ($agendamento->bancas()->where('tipo', 'Titular')->get() as $banca)
-                            {{ $agendamento->dadosProfessor($banca->codpes)->nome }}({{ $agendamento->dadosProfessor($banca->codpes)->lotado  ?? ''}})@if($loop->count != $loop->iteration), @endif
+                            {{ $agendamento->dadosProfessor($banca->codpes)['nompes'] }}({{ $agendamento->dadosProfessor($banca->codpes)['sglclgund'] ?? ''}})@if($loop->count != $loop->iteration), @endif
                         @endforeach
                     </td>
                     <td>

--- a/resources/views/comunicacao/index.blade.php
+++ b/resources/views/comunicacao/index.blade.php
@@ -28,12 +28,24 @@
               </div>
             </a>
           </td>
-        <td>{{$agendamento->resumo}}</td>
-        <td> {{\App\Models\Agendamento::telefoneProfessor($agendamento->orientador)}} </td>
+        <td><p> {{ $dadosJanus[0]['rsutrb'] }} </p> </td>
+        <td> {{\App\Models\Agendamento::dadosProfessor($agendamento->orientador)['nompes']}} </td>
         <td> {{date('d/m/Y', strtotime($agendamento->data_horario))}} </td>
     </tr>
     @endforeach
   </tbody>
 </table>
+{{ $agendamentos->appends(request()->query())->links() }}
+  
+<style>
+  p{
+    text-align:justify;
+    display:inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 120ch;"
+  }
+</style>
 
 @endsection

--- a/resources/views/comunicacao/index.blade.php
+++ b/resources/views/comunicacao/index.blade.php
@@ -29,7 +29,7 @@
             </a>
           </td>
         <td>{{$agendamento->resumo}}</td>
-        <td> {{\App\Models\Agendamento::dadosProfessor($agendamento->orientador)->nome}} </td>
+        <td> {{\App\Models\Agendamento::telefoneProfessor($agendamento->orientador)}} </td>
         <td> {{date('d/m/Y', strtotime($agendamento->data_horario))}} </td>
     </tr>
     @endforeach

--- a/resources/views/comunicacao/show.blade.php
+++ b/resources/views/comunicacao/show.blade.php
@@ -1,9 +1,6 @@
 @extends('laravel-usp-theme::master')
 @section("content")
 @include('flash')
-<form method="POST" action="/comunicacao/{{$comunicacao->id}}">
-    @csrf
-    @method("PATCH")
 <div class="container">
     <div class="card">
         <div class="card-header">
@@ -14,17 +11,12 @@
                 <div class="col">
                     <p><b>Título:</b> {{ $comunicacao->titulo }}</p>
                     <p><b>Autor:</b> {{ $comunicacao->nome }}, {{ $comunicacao->codpes }}</p>
-                    <p><b>Orientador:</b> {{ $comunicacao->docente->nome }}, {{ $comunicacao->orientador }}</p>
+                    {{-- <p><b>Orientador:</b> {{ $comunicacao->docente->nome }}, {{ $comunicacao->orientador }}</p> --}}
+                    
                     <p><b>Data:</b> {{ date('d/m/Y', strtotime($comunicacao->data_horario)) }}</p>
-                </div>
-                <div class="col">
-                    <p><b>Resumo: </b>{{ $comunicacao->resumo }}
+                    <p style="text-align:justify;"><b>Resumo: </b>{{ $dadosJanus[0]['rsutrb'] }}
                 </p>
             </div>
-        </div>
-        <hr />
-                <button type="submit" class="btn btn-success" name="agendamento_id" value="{{$comunicacao->id}}">Placeholder</button>
-            </form>
         </div>
     </div>
 </div>

--- a/resources/views/comunicacao/show.blade.php
+++ b/resources/views/comunicacao/show.blade.php
@@ -11,8 +11,7 @@
                 <div class="col">
                     <p><b>Título:</b> {{ $comunicacao->titulo }}</p>
                     <p><b>Autor:</b> {{ $comunicacao->nome }}, {{ $comunicacao->codpes }}</p>
-                    {{-- <p><b>Orientador:</b> {{ $comunicacao->docente->nome }}, {{ $comunicacao->orientador }}</p> --}}
-                    
+                    <p><b>Orientador:</b> {{ $comunicacao::dadosProfessor($comunicacao->orientador)['nompes'] }}, {{ $comunicacao::retornarDadosProfessor($comunicacao->orientador)['codpes'] }}</p>
                     <p><b>Data:</b> {{ date('d/m/Y', strtotime($comunicacao->data_horario)) }}</p>
                     <p style="text-align:justify;"><b>Resumo: </b>{{ $dadosJanus[0]['rsutrb'] }}
                 </p>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -83,10 +83,10 @@
                     <td>{{ $agendamento->nivel }}</td>
                     <td>{{ $replicado::nomeAreaPrograma($agendamento->area_programa) }}</td>
                     <td>{{ $pessoa::dump($agendamento->orientador)['nompes'] }}</td>
-                    <td>{{ $agendamento->sala }}</td>
+                    <td>{{ $agendamento->sala}} {{$agendamento->sala_virtual}}</td>
                     <td> 
                         @foreach ($agendamento->bancas()->where('tipo', 'Titular')->get() as $banca)
-                            {{ $agendamento->dadosProfessor($banca->codpes)->nome }} ({{ $agendamento->dadosProfessor($banca->codpes)->lotado  ?? ''}})@if($loop->count != $loop->iteration), @endif
+                            {{ $agendamento->dadosProfessor($banca->codpes)['nompes'] }} ({{ $agendamento->dadosProfessor($banca->codpes)['sglclgund']}})@if($loop->count != $loop->iteration), @endif
                         @endforeach
                     </td>
                 </tr>

--- a/resources/views/pdfs/documentos_bancas/declaracao.blade.php
+++ b/resources/views/pdfs/documentos_bancas/declaracao.blade.php
@@ -72,8 +72,8 @@
 
         @foreach($professores as $componente)    
         <div class="col">
-            <b>{{$agendamento->dadosProfessor($componente->codpes)->nome ?? 'Professor não cadastrado'}}</b> 
-            <b>{{$agendamento->dadosProfessor($componente->codpes)->lotado ?? ' '}}</b>
+            <b>{{$agendamento->dadosProfessor($componente->codpes)['nompes']}}</b> 
+            <b>{{$agendamento->dadosProfessor($componente->codpes)['sglclgund']}}</b>
         </div>
         @endforeach
 	<div style="margin-top:2cm;" align="center"> 

--- a/resources/views/pdfs/documentos_bancas/invite.blade.php
+++ b/resources/views/pdfs/documentos_bancas/invite.blade.php
@@ -66,7 +66,7 @@
     <div class="moremargin">Subject: @if($agendamento->nivel == 'Mestrado') <b>Master's</b> @else <b>Doctorate's</b> @endif Examination Committee</div> 
     <div class="moremargin">Candidate: <b>{{$agendamento->nome}}</b> </div>
     <div class="moremargin">Area: <b>{{$replicado->nomeAreaProgramaEmIngles($agendamento->area_programa)}}</b> </div>
-    <div class="moremargin">Supervisor: {{ $agendamento->nome_orientador ?? $pessoa::dump($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) and {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)->nome}} @endif</div>
+    <div class="moremargin">Supervisor: {{ $agendamento::dadosProfessor($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) and {{$agendamento->dadosProfessor($agendamento->co_orientador)['nompes']}} @endif</div>
     <div class="moremargin">Title of the thesis: <i>{{$agendamento->title ?? $agendamento->titulo}} </i></div>
     <div class="importante">
         {!! $configs->important !!}
@@ -80,8 +80,8 @@
 
         @foreach($professores as $componente)    
         <div class="col">
-            {{$agendamento->dadosProfessor($componente->codpes)->nome ?? 'Professor não cadastrado'}} 
-           <b>{{$agendamento->dadosProfessor($componente->codpes)->lotado ?? ' '}}</b>
+            {{$agendamento->dadosProfessor($componente->codpes)['nompes']}} 
+           <b>{{$agendamento->dadosProfessor($componente->codpes)['sglclgund']}}</b>
         </div>
         @endforeach
 	<div class="importante" align="center"> 
@@ -96,11 +96,14 @@
 		</b>
     </p>
     <br>
-    {{$agendamento->dadosProfessor($professor->codpes)['nome'] ?? 'Professor não cadastrado'}}<br>
-    {{$agendamento->dadosProfessor($professor->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($professor->codpes)->bairro ?? ' '}} <br>
-    Post Code:{{$agendamento->dadosProfessor($professor->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($professor->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($professor->codpes)->estado ?? ' '}}
-    <br> Phone: {{$agendamento->dadosProfessor($professor->codpes)->telefone ?? ' '}}
-    <br>Email: {{$agendamento->dadosProfessor($professor->codpes)->email ?? ' '}}
+    {{$agendamento->dadosProfessor($professor->codpes)['nompes']}}<br>
+    {{$agendamento->endereco($professor->codpes)['epflgr']}},
+     {{$agendamento->endereco($professor->codpes)['cpllgr']}} - 
+    {{$agendamento->endereco($professor->codpes)['nombro']}} <br>
+    Post Code:{{$agendamento->endereco($professor->codpes)['codendptl'] ?? 'CEP'}} - {{$agendamento->endereco($professor->codpes)['cidloc'] ?? 'CIDADE'}}/{{$agendamento->endereco($professor->codpes)['sglest'] ?? 'ESTADO'}}
+
+    <br> Phone: {{$agendamento->dadosProfessor($professor->codpes)['numtelfmt']}}
+    <br>Email: {{$agendamento->dadosProfessor($professor->codpes)['codema']}}
 @endsection('content')
 
 @section('footer')

--- a/resources/views/pdfs/documentos_bancas/statement.blade.php
+++ b/resources/views/pdfs/documentos_bancas/statement.blade.php
@@ -69,8 +69,8 @@
 
         @foreach($professores as $componente)    
         <div class="col">
-            <b>{{$agendamento->dadosProfessor($componente->codpes)->nome ?? 'Professor não cadastrado'}}</b> 
-            <b>{{$agendamento->dadosProfessor($componente->codpes)->lotado ?? ' '}}</b>
+            <b>{{$agendamento->dadosProfessor($componente->codpes)['nompes']}}</b> 
+            <b>{{$agendamento->dadosProfessor($componente->codpes)['sglclgund']}}</b>
         </div>
         @endforeach
     <br><br>

--- a/resources/views/pdfs/documentos_bancas/suplente.blade.php
+++ b/resources/views/pdfs/documentos_bancas/suplente.blade.php
@@ -63,18 +63,18 @@
         São Paulo, {{ strftime('%d de %B de %Y', strtotime('today')) }}    
     </div><br>
 
-    Ilmo(a). Sr(a). {{$agendamento->dadosProfessor($professor->codpes)->nome ?? 'Professor não cadastrado'}}<br>
-    {{$agendamento->dadosProfessor($professor->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($professor->codpes)->bairro ?? ' '}} <br>
-    CEP:{{$agendamento->dadosProfessor($professor->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($professor->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($professor->codpes)->estado ?? ' '}}
-    <br> telefone: {{$agendamento->dadosProfessor($professor->codpes)->telefone ?? ' '}}
-    <br>e-mail: {{$agendamento->dadosProfessor($professor->codpes)->email ?? ' '}}
+    Ilmo(a). Sr(a). {{$agendamento->dadosProfessor($professor->codpes)['nompes'] }}<br>
+    {{$agendamento->endereco($professor->codpes)['nomloc'] ?? 'epflgr'}}, {{$agendamento->endereco($professor->codpes)['nombro'] ?? 'bairro'}} <br>
+    CEP:{{$agendamento->endereco($professor->codpes)['codendptl']}} - {{$agendamento->dadosProfessor($professor->codpes)['nomloc'] ?? 'cidade'}}/{{$agendamento->dadosProfessor($professor->codpes)['nomloc'] ?? 'estado'}}
+    <br> telefone: {{$agendamento->dadosProfessor($professor->codpes)['numtelfmt']}}
+    <br>e-mail: {{$agendamento->dadosProfessor($professor->codpes)['codema']}}
     <br><br>
 
     <div class="boxSuplente">
         <div class="moremargin">Assunto: Banca Examinadora de <b>{{$agendamento->nivel}}</b></div> 
         <div class="moremargin">Candidato(a): <b>{{$agendamento->nome}}</b> </div>
         <div class="moremargin">Área: <b>{{$agendamento->nome_area}}</b> </div>
-        <div class="moremargin">Orientador(a) Prof(a). Dr(a). {{ $agendamento->nome_orientador ?? $pessoa::dump($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) e {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)->nome}} @endif</div>
+        <div class="moremargin">Orientador(a) Prof(a). Dr(a). {{ $agendamento::dadosProfessor($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) e {{$agendamento->dadosProfessor($agendamento->co_orientador)['nompes']}} @endif</div>
         <div class="moremargin">Título do Trabalho: <i>{{$agendamento->titulo}} </i></div>
     </div>
 

--- a/resources/views/pdfs/documentos_bancas/titular.blade.php
+++ b/resources/views/pdfs/documentos_bancas/titular.blade.php
@@ -66,7 +66,7 @@
     <div class="moremargin">Assunto: Banca Examinadora de <b>{{$agendamento->nivel}}</b></div> 
     <div class="moremargin">Candidato(a): <b>{{$agendamento->nome}}</b> </div>
     <div class="moremargin">Área: <b>{{$agendamento->nome_area}}</b> </div>
-    <div class="moremargin">Orientador(a) Prof(a). Dr(a). {{ $agendamento->nome_orientador ?? $pessoa::dump($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) e {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)->nome}} @endif</div>
+    <div class="moremargin">Orientador(a) Prof(a). Dr(a). {{ $agendamento::dadosProfessor($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) e {{ $agendamento->dadosProfessor($agendamento->co_orientador)['nompes']}} @endif</div>
     <div class="moremargin">Título do Trabalho: <i>{{$agendamento->titulo}} </i></div>
     <div class="importante">
         {!! $configs->importante_oficio !!}
@@ -80,8 +80,8 @@
 
         @foreach($professores as $componente)    
         <div class="col">
-            {{$agendamento->dadosProfessor($componente->codpes)->nome ?? 'Professor não cadastrado'}} 
-           <b>{{$agendamento->dadosProfessor($componente->codpes)->lotado ?? ' '}}</b>
+            {{$agendamento->dadosProfessor($componente->codpes)['nompes'] }} 
+           <b>{{$agendamento->dadosProfessor($componente->codpes)['sglclgund']}}</b>
         </div>
         @endforeach
 	<div class="importante" align="center"> 
@@ -95,11 +95,11 @@
 		</b>
     </p>
     <br> 
-    Ilmo(a). Sr(a). {{$agendamento->dadosProfessor($professor->codpes)['nome'] ?? 'Professor não cadastrado'}}<br>
-    {{$agendamento->dadosProfessor($professor->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($professor->codpes)->bairro ?? ' '}} <br>
-    CEP:{{$agendamento->dadosProfessor($professor->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($professor->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($professor->codpes)->estado ?? ' '}}
-    <br> telefone: {{$agendamento->dadosProfessor($professor->codpes)->telefone ?? ' '}}
-    <br>e-mail: {{$agendamento->dadosProfessor($professor->codpes)->email ?? ' '}}
+    Ilmo(a). Sr(a). {{$agendamento->dadosProfessor($professor->codpes)['nompes']}}<br>
+    {{$agendamento->endereco($professor->codpes)['epflgr']}}, {{$agendamento->endereco($professor->codpes)['cpllgr']}} - {{$agendamento->endereco($professor->codpes)['nombro']}} <br>
+    CEP:{{$agendamento->endereco($professor->codpes)['codendptl'] ?? ' '}} - {{$agendamento->endereco($professor->codpes)['cidloc']}}/{{$agendamento->endereco($professor->codpes)['sglest']}}
+    <br> telefone: {{$agendamento->dadosProfessor($professor->codpes)['numtelfmt']}}
+    <br>e-mail: {{$agendamento->dadosProfessor($professor->codpes)['codema']}}
 @endsection('content')
 
 @section('footer')

--- a/resources/views/pdfs/documentos_gerais/declaracoes.blade.php
+++ b/resources/views/pdfs/documentos_gerais/declaracoes.blade.php
@@ -73,8 +73,8 @@
 
         @foreach($bancas as $banca)    
         <div class="col">
-            <b>{{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}}</b> 
-            <b>{{$agendamento->dadosProfessor($banca->codpes)->lotado ?? ' '}}</b>
+            <b>{{$agendamento->dadosProfessor($banca->codpes)['nompes']}}</b> 
+            <b>{{$agendamento->dadosProfessor($banca->codpes)['sglclgund']}}</b>
         </div>
             @endforeach
         <div style="margin-top:2cm;" align="center"> 

--- a/resources/views/pdfs/documentos_gerais/documento_zero.blade.php
+++ b/resources/views/pdfs/documentos_gerais/documento_zero.blade.php
@@ -39,17 +39,17 @@
     </b>
 
   @foreach($professores as $professor)
-      @if($agendamento->dadosProfessor($professor->codpes)->docente_usp == 'nao')
+      @if($agendamento->dadosProfessor($professor->codpes)['tipvinext'] == 'Docente')
           <table style="border: 1px solid black; border-spacing: 5px; width: 18.6cm;">
             <tr>
               <td>
-                Prof: <b> {{$agendamento->dadosProfessor($professor->codpes)->nome ?? 'Professor não cadastrado'}}  </b>
+                Prof: <b> {{$agendamento->dadosProfessor($professor->codpes)['nompes']}}  </b>
               </td>
             </tr>
             <tr>
               <td>
-                PASSAGEM: {{$agendamento->dadosProfessor($professor->codpes)->cidade ?? ''}}/
-                {{$agendamento->dadosProfessor($professor->codpes)->estado ?? ''}}
+                PASSAGEM: {{$agendamento->endereco($professor->codpes)['cidloc'] ?? 'cidade'}}/
+                {{$agendamento->dadosProfessor($professor->codpes)['sglest'] ?? 'estado'}}
               </td>
             </tr>
             <tr>

--- a/resources/views/pdfs/documentos_gerais/etiqueta.blade.php
+++ b/resources/views/pdfs/documentos_gerais/etiqueta.blade.php
@@ -31,9 +31,9 @@
         <tr>
             <td width="9.85cm" height="3.33cm">
                 Ilmo(a) Sr(a).<br>
-                {{$agendamento->dadosProfessor($professor->codpes)['nome'] ?? 'Professor não cadastrado'}}<br>
-                {{$agendamento->dadosProfessor($professor->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($professor->codpes)->bairro ?? ' '}} <br>
-                CEP:{{$agendamento->dadosProfessor($professor->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($professor->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($professor->codpes)->estado ?? ' '}}
+                {{$agendamento->dadosProfessor($professor->codpes)['nompes']}}<br>
+                {{$agendamento->endereco($professor->codpes)['epflgr']}}, {{$agendamento->endereco($professor->codpes)['nombro']}} <br>
+                CEP:{{$agendamento->endereco($professor->codpes)['codendptl']}} - {{$agendamento->endereco($professor->codpes)['cidloc']}}/{{$agendamento->endereco($professor->codpes)['sglest']}}
             </td>     
         </tr>
     @endforeach

--- a/resources/views/pdfs/documentos_gerais/invites.blade.php
+++ b/resources/views/pdfs/documentos_gerais/invites.blade.php
@@ -67,7 +67,7 @@
             <div class="moremargin">Subject: @if($agendamento->nivel == 'Mestrado') <b>Master's</b> @else <b>Doctorate's</b> @endif Examination Committee</div> 
             <div class="moremargin">Candidate: <b>{{$agendamento->nome}}</b> </div>
             <div class="moremargin">Area: <b>{{$replicado->nomeAreaProgramaEmIngles($agendamento->area_programa)}}</b> </div>
-            <div class="moremargin">Supervisor: {{ $agendamento->nome_orientador ?? $pessoa::dump($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) and {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)->nome}} @endif</div>
+            <div class="moremargin">Supervisor: {{ $agendamento->nome_orientador ?? $agendamento::dadosProfessor($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) and {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)['nompes']}} @endif</div>
             <div class="moremargin">Title of the thesis: <i>{{$agendamento->title ?? $agendamento->titulo}} </i></div>
             <div class="importante">
                 {!! $configs->important !!}
@@ -81,8 +81,8 @@
 
                 @foreach($bancas as $banca)    
                 <div class="col">
-                    {{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}} 
-                   <b>{{$agendamento->dadosProfessor($banca->codpes)->lotado ?? ' '}}</b>
+                    {{$agendamento->dadosProfessor($banca->codpes)['nompes']}} 
+                   <b>{{$agendamento->dadosProfessor($banca->codpes)['sglclgund']}}</b>
                 </div>
                 @endforeach
             <div class="importante" align="center"> 
@@ -96,11 +96,11 @@
                 </b>
             </div>
             <br>
-            {{$agendamento->dadosProfessor($professor->codpes)['nome'] ?? 'Professor não cadastrado'}}<br>
-            {{$agendamento->dadosProfessor($professor->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($professor->codpes)->bairro ?? ' '}} <br>
-            Post Code:{{$agendamento->dadosProfessor($professor->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($professor->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($professor->codpes)->estado ?? ' '}}
-            <br> Phone: {{$agendamento->dadosProfessor($professor->codpes)->telefone ?? ' '}}
-            <br>Email: {{$agendamento->dadosProfessor($professor->codpes)->email ?? ' '}}
+            {{$agendamento->dadosProfessor($professor->codpes)['nompes'] ?? 'Professor não cadastrado'}}<br>
+            {{$agendamento->endereco($professor->codpes)['epflgr']}}, {{$agendamento->endereco($professor->codpes)['nombro']}} <br>
+            Post Code:{{$agendamento->endereco($professor->codpes)['codendptl']}} - {{$agendamento->endereco($professor->codpes)['cidloc']}}/{{$agendamento->endereco($professor->codpes)['sglest'] ?? 'ESTADO'}}
+            <br> Phone: {{$agendamento->dadosProfessor($professor->codpes)['numtelfmt']}}
+            <br>Email: {{$agendamento->dadosProfessor($professor->codpes)['codema']}}
         </p>
         <p class="page-break"></p> 
     @endforeach

--- a/resources/views/pdfs/documentos_gerais/recibos.blade.php
+++ b/resources/views/pdfs/documentos_gerais/recibos.blade.php
@@ -36,7 +36,7 @@
 	@inject('pessoa','Uspdev\Replicado\Pessoa')
 	@foreach($professores as $professor)
 		<br><br>
-		@if($agendamento->dadosProfessor($professor->codpes)->docente_usp == 'sim')
+		@if($agendamento->dadosProfessor($professor->codpes)['tipvinext'] == 'Docente')
 			<table width="18cm" class="negrito">
 				<tr>
 					<td> RECIBO DE REMESSA DE DOCUMENTOS </td> 
@@ -47,10 +47,10 @@
 				<tr>
 					<td> 
 						<u>DO:</u> SERVIÇO DE PÓS-GRADUAÇÃO DA FFLCH <br>
-						<u>PARA:</u> {{$agendamento->dadosProfessor($professor->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($professor->codpes)->bairro ?? ' '}} <br>
-							CEP:{{$agendamento->dadosProfessor($professor->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($professor->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($professor->codpes)->estado ?? ' '}}
+						<u>PARA:</u> {{$agendamento->endereco($professor->codpes)['epflgr']}}, {{$agendamento->endereco($professor->codpes)['nombro']}} <br>
+							CEP:{{$agendamento->endereco($professor->codpes)['codendptl']}} - {{$agendamento->endereco($professor->codpes)['cidloc']}}/{{$agendamento->endereco($professor->codpes)['sglest']}}
 						<div style="text-indent:1.5cm;">
-							A/C: Prof(a). Dr(a). {{$agendamento->dadosProfessor($professor->codpes)->nome ?? 'Professor não cadastrado'}}
+							A/C: Prof(a). Dr(a). {{$agendamento->dadosProfessor($professor->codpes)['nompes']}}
 						</div> 
 					</td> 
 				</tr> 
@@ -88,9 +88,9 @@
 				<tr>
 					<td>
 						<u>DO:</u> SERVIÇO DE PÓS-GRADUAÇÃO DA FFLCH <br>
-						<u>PARA:</u>  {{$agendamento->dadosProfessor($professor->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($professor->codpes)->bairro ?? ' '}} <br>
-							CEP:{{$agendamento->dadosProfessor($professor->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($professor->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($professor->codpes)->estado ?? ' '}}
-						<div style="text-indent:1.5cm;"> A/C: Prof(a). Dr(a). {{$agendamento->dadosProfessor($professor->codpes)->nome ?? 'Professor não cadastrado'}} </div> 
+						<u>PARA:</u>  {{$agendamento->endereco($professor->codpes)['epflgr']}}, {{$agendamento->endereco($professor->codpes)['nombro']}} <br>
+							CEP:{{$agendamento->endereco($professor->codpes)['codendptl']}} - {{$agendamento->endereco($professor->codpes)['cidloc']}}/{{$agendamento->endereco($professor->codpes)['sglest']}}
+						<div style="text-indent:1.5cm;"> A/C: Prof(a). Dr(a). {{$agendamento->dadosProfessor($professor->codpes)['nompes']}} </div> 
 					</td> 
 				</tr>
 			</table>

--- a/resources/views/pdfs/documentos_gerais/statements.blade.php
+++ b/resources/views/pdfs/documentos_gerais/statements.blade.php
@@ -68,8 +68,8 @@
 
             @foreach($bancas as $banca)    
             <div class="col">
-                <b>{{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}}</b> 
-                <b>{{$agendamento->dadosProfessor($banca->codpes)->lotado ?? ' '}}</b>
+                <b>{{$agendamento->dadosProfessor($banca->codpes)['nompes']}}</b> 
+                <b>{{$agendamento->dadosProfessor($banca->codpes)['sglclgund']}}</b>
             </div>
             @endforeach
         <br>

--- a/resources/views/pdfs/documentos_gerais/suplentes.blade.php
+++ b/resources/views/pdfs/documentos_gerais/suplentes.blade.php
@@ -63,23 +63,23 @@
             São Paulo, {{ strftime('%d de %B de %Y', strtotime('today')) }}
         </div><br><br>
 
-        Ilmo(a). Sr(a). {{$agendamento->dadosProfessor($professor->codpes)['nome'] ?? 'Professor não cadastrado'}}<br>
-        {{$agendamento->dadosProfessor($professor->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($professor->codpes)->bairro ?? ' '}} <br>
-        CEP:{{$agendamento->dadosProfessor($professor->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($professor->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($professor->codpes)->estado ?? ' '}}
-        <br> telefone: {{$agendamento->dadosProfessor($professor->codpes)->telefone ?? ' '}}
-        <br>e-mail: {{$agendamento->dadosProfessor($professor->codpes)->email ?? ' '}}
+        Ilmo(a). Sr(a). {{$agendamento->dadosProfessor($professor->codpes)['nompes']}}<br>
+        {{$agendamento->endereco($professor->codpes)['epflgr']}}, {{$agendamento->endereco($professor->codpes)['nombro']}} <br>
+        CEP:{{$agendamento->endereco($professor->codpes)['codendptl']}} - {{$agendamento->endereco($professor->codpes)['cidloc']}}/{{$agendamento->endereco($professor->codpes)['sglest']}}
+        <br> telefone: {{$agendamento->dadosProfessor($professor->codpes)['numtelfmt']}}
+        <br>e-mail: {{$agendamento->dadosProfessor($professor->codpes)['codema']}}
         <br>
 
         <div class="boxSuplente">
             <div class="moremargin">Assunto: Banca Examinadora de <b>{{$agendamento->nivel}}</b></div> 
             <div class="moremargin">Candidato(a): <b>{{$agendamento->nome}}</b> </div>
             <div class="moremargin">Área: <b>{{$agendamento->nome_area}}</b> </div>
-            <div class="moremargin">Orientador(a) Prof(a). Dr(a). {{ $agendamento->nome_orientador ?? $pessoa::dump($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) e {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)->nome}} @endif</div>
+            <div class="moremargin">Orientador(a) Prof(a). Dr(a). {{ $agendamento->nome_orientador ?? $pessoa::dump($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) e {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)['nompes']}} @endif</div>
             <div class="moremargin">Título do Trabalho: <i>{{$agendamento->titulo}} </i></div>
         </div>
 
         <br>
-        <div class="oficioSuplente">Sr(a). Prof(a). {{$agendamento->dadosProfessor($professor->codpes)->nome ?? 'Professor não cadastrado'}} </div>
+        <div class="oficioSuplente">Sr(a). Prof(a). {{$agendamento->dadosProfessor($professor->codpes)['nompes']}} </div>
 
         <div style="text-align:justify;">
             {!! $configs->oficio_suplente !!}

--- a/resources/views/pdfs/documentos_gerais/titulares.blade.php
+++ b/resources/views/pdfs/documentos_gerais/titulares.blade.php
@@ -68,7 +68,7 @@
             <div class="moremargin">Assunto: Banca Examinadora de <b>{{$agendamento->nivel}}</b></div>
             <div class="moremargin">Candidato(a): <b>{{$agendamento->nome}}</b> </div>
             <div class="moremargin">Área: <b>{{$agendamento->nome_area}}</b> </div>
-            <div class="moremargin">Orientador(a) Prof(a). Dr(a). {{ $agendamento->nome_orientador ?? $pessoa::dump($agendamento->orientador)['nompes'] }} @if($agendamento->co_orientador) e {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)->nome}} @endif</div>
+            <div class="moremargin">Orientador(a) Prof(a). Dr(a). {{ $agendamento->nome_orientador ?? $pessoa::dump($agendamento->orientador)['nompes'] }} @if($agendamento->co_orientador) e {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)['nompes']}} @endif</div>
             <div class="moremargin">Título do Trabalho: <i>{{$agendamento->titulo}} </i></div>
             <div class="importante" align="center">
                 {!! $configs->importante_oficio !!}
@@ -81,8 +81,8 @@
 
                 @foreach($bancas as $banca)
                 <div class="col">
-                    {{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}} 
-                   <b>{{$agendamento->dadosProfessor($banca->codpes)->lotado ?? ' '}}</b>
+                    {{$agendamento->dadosProfessor($banca->codpes)['nompes']}} 
+                   <b>{{$agendamento->dadosProfessor($banca->codpes)['sglclgund']}}</b>
                 </div>
                 @endforeach
             <div class="importante" align="center">
@@ -94,11 +94,11 @@
                     {{Auth::user()->name}} @if($pessoa::cracha(Auth::user()->codpes)) - Defesas de Mestrado e Doutorado da {{$pessoa::cracha(Auth::user()->codpes)['nomorg']}}/USP @endif
                 </b>
             </div><br>
-            Ilmo(a). Sr(a). {{$agendamento->dadosProfessor($professor->codpes)['nome'] ?? 'Professor não cadastrado'}}<br>
-            {{$agendamento->dadosProfessor($professor->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($professor->codpes)->bairro ?? ' '}} <br>
-            CEP:{{$agendamento->dadosProfessor($professor->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($professor->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($professor->codpes)->estado ?? ' '}}
-            <br> telefone: {{$agendamento->dadosProfessor($professor->codpes)->telefone ?? ' '}}
-            <br>e-mail: {{$agendamento->dadosProfessor($professor->codpes)->email ?? ' '}}
+            Ilmo(a). Sr(a). {{$agendamento->dadosProfessor($professor->codpes)['nompes']}}<br>
+            {{$agendamento->endereco($professor->codpes)['epflgr']}}, {{$agendamento->endereco($professor->codpes)['nombro']}} <br>
+            CEP:{{$agendamento->endereco($professor->codpes)['codendptl']}} - {{$agendamento->endereco($professor->codpes)['cidloc']}}/{{$agendamento->endereco($professor->codpes)['sglest']}}
+            <br> telefone: {{$agendamento->dadosProfessor($professor->codpes)['numtelfmt']}}
+            <br>e-mail: {{$agendamento->dadosProfessor($professor->codpes)['codema']}}
         </p>
         <p class="page-break"></p>
     @endforeach

--- a/resources/views/pdfs/recibos/auxilio_passagem.blade.php
+++ b/resources/views/pdfs/recibos/auxilio_passagem.blade.php
@@ -16,12 +16,12 @@
     <left> <u><b>{{$dados->processo}}</b></u> </left> <br> 
 
     <p> Banca de defesa de <b> {{$agendamento->nome}} </p> 
-    <p> Passageiro(a) {{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}} </p> 
+    <p> Passageiro(a) {{$agendamento->dadosProfessor($banca->codpes)['nompes']}} </p> 
     <p> Itinerário: {{$dados->itinerario}} </p> 
     <p> Partida: {{$dados->partida}}</p> 
     <p> Retorno: {{$dados->retorno}} </p> 
-    <p> Telefone: {{$agendamento->dadosProfessor($banca->codpes)->telefone ?? ' '}} </p> 
-    <p> E-mail: {{$agendamento->dadosProfessor($banca->codpes)->email ?? ' '}}
+    <p> Telefone: {{$agendamento->dadosProfessor($banca->codpes)['numtelfmt']}} </p> 
+    <p> E-mail: {{$agendamento->dadosProfessor($banca->codpes)['codema']}}
     </p> 
     <div class="justificar"> {!! $configs->obs_passagem !!} </div>
             

--- a/resources/views/pdfs/recibos/passagem.blade.php
+++ b/resources/views/pdfs/recibos/passagem.blade.php
@@ -43,13 +43,13 @@
 		<li>Programa: <b>{{$agendamento->nome_area}} </b> </li>  
     <li><b>{{$agendamento->nivel}} </b> </li>  
 		<li>Defesa do Sr.(a): <b> {{$agendamento->nome}} </b> </li>  
-		<li>Orientador(a): Prof(a) Dr(a)<b> {{$agendamento->nome_orientador ?? $pessoa::dump($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) e {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)->nome}} @endif </b> </li>
+		<li>Orientador(a): Prof(a) Dr(a)<b> {{$agendamento->nome_orientador ?? $pessoa::dump($agendamento->orientador)['nompes']}} @if($agendamento->co_orientador) e {{$agendamento->nome_co_orientador ?? $agendamento->dadosProfessor($agendamento->co_orientador)['nompes']}} @endif </b> </li>
     </ul>
 	<div class="justificar" style="text-indent:1cm;" >{!! $configs->agencia_texto !!} </div>
 	<div class="importante">  
-		Interessado(a): Prof(a). Dr(a). <b> {{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}}</b> <br>
-		E-mail: <b>{{$agendamento->dadosProfessor($banca->codpes)->email ?? ' '}}</b> <br>
-		Telefone:<b> {{$agendamento->dadosProfessor($banca->codpes)->telefone ?? ' '}} </b> <br>
+		Interessado(a): Prof(a). Dr(a). <b> {{$agendamento->dadosProfessor($banca->codpes)['nompes']}}</b> <br>
+		E-mail: <b>{{$agendamento->dadosProfessor($banca->codpes)['codema']}}</b> <br>
+		Telefone:<b> {{$agendamento->dadosProfessor($banca->codpes)['numtelfmt']}} </b> <br>
 		Data da defesa:<b> {{date('d/m/Y', strtotime($agendamento->data_horario))}}</b> <br>
 		Trajeto da passagem aérea <b> {{$dados->trajeto}}</b> <br>
 	</div> <br>

--- a/resources/views/pdfs/recibos/proap.blade.php
+++ b/resources/views/pdfs/recibos/proap.blade.php
@@ -45,18 +45,18 @@
         <hr>
         <table width="16.5cm" style="border:0px;">
 			<tr>
-				<td style="border:0px;" colspan="2">Nome do Convidado: {{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}} </td>
+				<td style="border:0px;" colspan="2">Nome do Convidado: {{$agendamento->dadosProfessor($banca->codpes)['nompes']}} </td>
 			</tr>
 			<tr>
-				<td style="border:0px;"> CPF: {{$agendamento->dadosProfessor($banca->codpes)->cpf ?? ' '}}</td>
-				<td style="border:0px;">  RG: {{$agendamento->dadosProfessor($banca->codpes)->documento ?? ' '}}  </td>
+				<td style="border:0px;"> CPF: {{$agendamento->retornarDadosProfessor($banca->codpes)['numcpf']}}</td>
+				<td style="border:0px;">  RG: {{$agendamento->retornarDadosProfessor($banca->codpes)['numdocidf']}}  </td>
 			</tr>
 		</table>				
 	    <hr>
 	    <table width="16.5cm" style="border:0px;">
 			<tr>
 				<td style="border:0px;">Unidade: </td>
-				<td style="border:0px;"> {{$agendamento->dadosProfessor($banca->codpes)->lotado ?? ' '}} </td>
+				<td style="border:0px;"> {{$agendamento->dadosProfessor($banca->codpes)['sglclgund']}} </td>
 				<td style="border:0px;">Cargo: </td>
 				<td style="border:0px;"> <b> Professor(a) Doutor(a) </b> </td>
 			</tr>
@@ -107,14 +107,14 @@
 	    <table width="18cm"> 
 			<tr>
 				<td style="border:none;"> <hr style="width:10cm;"> 
-					{{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}} <br> 
-					<b>{{$agendamento->dadosProfessor($banca->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($banca->codpes)->bairro ?? ' '}} <br>
-        			CEP:{{$agendamento->dadosProfessor($banca->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($banca->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($banca->codpes)->estado ?? ' '}}
+					{{$agendamento->dadosProfessor($banca->codpes)['nompes']}} <br> 
+					<b>{{$agendamento->endereco($banca->codpes)['epflgr']}}, {{$agendamento->endereco($banca->codpes)['nombro']}} <br>
+        			CEP:{{$agendamento->endereco($banca->codpes)['codendptl']}} - {{$agendamento->endereco($banca->codpes)['cidloc']}}/{{$agendamento->endereco($banca->codpes)['sglest']}}
 				</td>
 			</tr> 
 		</table>
 
-	    <center> <b> {{$agendamento->dadosProfessor($banca->codpes)->email ?? ' '}}</b> </center>
+	    <center> <b> {{$agendamento->dadosProfessor($banca->codpes)['codema']}}</b> </center>
 	    <br> <center> <b>RELATÓRIO </center></b> <br> <div class="justificar">  {!! $configs->capes_proap !!} </div> 
 	    Banca de: {{$agendamento->nome}} <br><br><br><br><br><br><br>
         <table width="18cm"> 

--- a/resources/views/pdfs/recibos/proex.blade.php
+++ b/resources/views/pdfs/recibos/proex.blade.php
@@ -62,17 +62,17 @@
 			</td>
 		</tr> 
 		<tr>
-			<td> Nome: {{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}}	</td>
-			<td> CPF: {{$agendamento->dadosProfessor($banca->codpes)->cpf ?? ' '}} </td>
+			<td> Nome: {{$agendamento->dadosProfessor($banca->codpes)['nompes'] ?? 'Professor não cadastrado'}}	</td>
+			<td> CPF: {{$agendamento->retornarDadosProfessor($banca->codpes)['numcpf']}} </td>
 		</tr>
 		<tr>
 			<td> Profissão: <br> PROFESSOR DOUTOR	</td>
-			<td> RG/Passaporte(se estrangeiro):<br> {{$agendamento->dadosProfessor($banca->codpes)->documento ?? ' '}} </td>
+			<td> RG/Passaporte(se estrangeiro):<br> {{$agendamento->retornarDadosProfessor($banca->codpes)['numdocidf']}} </td>
 		</tr>
 		<tr>
 			<td colspan="2"> Endereço Completo: <br> 
-			{{$agendamento->dadosProfessor($banca->codpes)->endereco ?? ' '}}, {{$agendamento->dadosProfessor($banca->codpes)->bairro ?? ' '}} <br>
-        	CEP:{{$agendamento->dadosProfessor($banca->codpes)->cep ?? ' '}} - {{$agendamento->dadosProfessor($banca->codpes)->cidade ?? ' '}}/{{$agendamento->dadosProfessor($banca->codpes)->estado ?? ' '}}
+			{{$agendamento->endereco($banca->codpes)['epflgr']}}, {{$agendamento->endereco($banca->codpes)['nombro']}} <br>
+        	CEP:{{$agendamento->endereco($banca->codpes)['codendptl']}} - {{$agendamento->endereco($banca->codpes)['cidloc']}}/{{$agendamento->endereco($banca->codpes)['sglest']}}
 			</td>
 		</tr>
 	</table> 
@@ -122,7 +122,7 @@
 		</tr>
 		<tr>
 			<td>  <b> <center>{{$replicado::coordenadorArea($agendamento->area_programa)['nompes']}}</b> </center>	</td>
-			<td> <b> <center>{{$agendamento->dadosProfessor($banca->codpes)->nome ?? 'Professor não cadastrado'}}</b> </center> </td>
+			<td> <b> <center>{{$agendamento->dadosProfessor($banca->codpes)['nompes']}}</b> </center> </td>
 		</tr>
 	</table> 
     <p style="font-size: 9px;"> <b>ATENÇÃO:</b> Utilizar esse modelo quando ocorrer pagamento de diárias ou remuneração de serviço a pessoas físicas que não possuam talonários de Notas Fiscais de Serviços (<b> Outros Serviços de Terceiros - Pessoas Físicas </b>) </p>


### PR DESCRIPTION
- Métodos implementados no model Agendamento para pegar as informações dos docentes por meio do Replicado
- No CommunicationController, foi excluído o método store: o controller só retorna views para consulta (sem necessidade de filtro de busca até o momento).
- Exclusão, por meio de migration, da tabela "communications"
- Adicionando o código do programa/área no form de criação/edição de agendamentos
- Impedindo o sistema colocar a data 31/12/1969 como placeholder no mesmo form.